### PR TITLE
fix: 헤더, 하단 네비게이션 고정

### DIFF
--- a/src/components/layout/TheHeader.tsx
+++ b/src/components/layout/TheHeader.tsx
@@ -24,7 +24,11 @@ const TheHeader = ({ type }: TheHeaderProps) => {
 export default TheHeader;
 
 const Header = styled.header<{ type: HeaderType }>`
+  position: sticky;
+  top: 0;
+  z-index: 100;
   height: ${HEADER_HEIGHT}px;
   text-align: ${(props) => props.type};
   padding: ${({ theme }) => theme.spacing[4]};
+  background-color: ${({ theme }) => theme.colors.background};
 `;

--- a/src/components/layout/TheNavigation.tsx
+++ b/src/components/layout/TheNavigation.tsx
@@ -47,6 +47,10 @@ const TheNavigation = () => {
 export default TheNavigation;
 
 const Navigation = styled.nav`
+  position: sticky;
+  bottom: 0;
+  z-index: 100;
+  background-color: ${({ theme }) => theme.colors.background};
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   height: ${NAV_HEIGHT}px;


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

헤더, 하단 네비게이션 바가 화면 아래쪽에 고정되지 않는 문제를 수정하였습니다. 

## 🔗 작업 내용

- [x] 헤더 sticky 추가
- [x] 하단 네비게이션 sticky 추가

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

헤더, 네비게이션에 sticky를 추가하여 화면에 붙도록 설정하였습니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #18 
